### PR TITLE
Make output writer a configurable field

### DIFF
--- a/.github/workflows/push-build-test-on-push.yml
+++ b/.github/workflows/push-build-test-on-push.yml
@@ -1,8 +1,8 @@
 on: push
 name: Build & test
 jobs:
-  buildAndTest:
-    name: Build & Test
+  buildAndTestDocker:
+    name: Build & Test Docker Image
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -10,3 +10,10 @@ jobs:
       uses: parkr/actions/docker-make@main
       with:
         args: docker-test -e REV=${{ github.sha }}
+  goTest:
+    name: Test (go)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v3
+      - run: go test -v ./...

--- a/.github/workflows/push-build-test-on-push.yml
+++ b/.github/workflows/push-build-test-on-push.yml
@@ -16,4 +16,5 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v3
+      - run: mkdir -p tmp
       - run: go test -v ./...

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ archive
 .env
 instapaper-export.csv
 instapaper-archive
+tmp/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang
+FROM golang:1.18.1
 
 WORKDIR /srv/instapaper-archive
 COPY . .

--- a/data.go
+++ b/data.go
@@ -12,6 +12,8 @@ import (
 type bookmarkData struct {
 	Bookmark           *instapaper.Bookmark
 	BookmarkExportMeta *bookmarkExportMeta
+	Highlights         []instapaper.Highlight `json:"-"`
+	FullText           string                 `json:"-"`
 }
 
 type bookmarkExportMeta struct {

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/parkr/instapaper-archive
 go 1.16
 
 require (
+	github.com/gomodule/oauth1 v0.2.0
 	github.com/ochronus/instapaper-go-client v1.0.1-0.20210326052024-1eed9710be3a
-	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,7 @@
-github.com/gomodule/oauth1 v0.0.0-20181215000758-9a59ed3b0a84 h1:NlNEdePx7QY9Z4rds4EIe1dvUT8Ao1PZgLS80S5YTbU=
 github.com/gomodule/oauth1 v0.0.0-20181215000758-9a59ed3b0a84/go.mod h1:4r/a8/3RkhMBxJQWL5qzbOEcaQmNPIkNoI7P8sXeI08=
+github.com/gomodule/oauth1 v0.2.0 h1:/nNHAD99yipOEspQFbAnNmwGTZ1UNXiD/+JLxwx79fo=
+github.com/gomodule/oauth1 v0.2.0/go.mod h1:4r/a8/3RkhMBxJQWL5qzbOEcaQmNPIkNoI7P8sXeI08=
 github.com/nikhilm/gocco v0.0.0-20120406065426-84d2aea39070/go.mod h1:mkS7uyvWaMapPDrUsq96p/zFsh88Iblu6eWO+qt0Zv0=
-github.com/ochronus/instapaper-go-client v1.0.0 h1:XIs303NAhTUVDwcwD4VNiRi4xrRbJRepkPYLygqt1pg=
-github.com/ochronus/instapaper-go-client v1.0.0/go.mod h1:vrigQWRGBG+oTAikxCDcEiwRnkuK69AtgiBwBMu922o=
 github.com/ochronus/instapaper-go-client v1.0.1-0.20210326052024-1eed9710be3a h1:YLwNWzRBE2n/+ePx1qqtoGKsgQfCjss3zyoGvzJfRV4=
 github.com/ochronus/instapaper-go-client v1.0.1-0.20210326052024-1eed9710be3a/go.mod h1:vrigQWRGBG+oTAikxCDcEiwRnkuK69AtgiBwBMu922o=
 github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR/rfWxYHBV53g=
@@ -10,14 +9,7 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20201002202402-0a1ea396d57c/go.mod h1:iQL9McJNjoIa5mjH6nYTCTZXUN6RP+XW3eib7Ya3XcI=
-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 h1:DzZ89McO9/gWPsQXS/FVKAlG02ZjaQ6AlZRBimEYOd0=
-golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.6/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
-golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/job.go
+++ b/job.go
@@ -1,18 +1,17 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
-	"path/filepath"
-	"strings"
 
 	"github.com/ochronus/instapaper-go-client/instapaper"
 )
+
+type OutputWriter interface {
+	Preflight() error
+	Write(bookmarkData) error
+}
 
 type InstapaperBookmarkDownloadJob struct {
 	APIClient        *instapaper.Client
@@ -20,93 +19,30 @@ type InstapaperBookmarkDownloadJob struct {
 	HighlightService *instapaper.HighlightService
 	Directory        string
 	BookmarkData     *bookmarkData
+	OutputWriter     OutputWriter
 }
 
-func (j *InstapaperBookmarkDownloadJob) Process() {
+func (j *InstapaperBookmarkDownloadJob) Process() error {
 	log.Printf("[%s] data: %s", j.BookmarkData.GetID(), j.BookmarkData)
-	var text string
 	if j.BookmarkData.Bookmark != nil && j.BookmarkData.Bookmark.ID > 0 {
-		text, _ = j.BookmarkService.GetText(j.BookmarkData.Bookmark.ID)
+		// Fill out what we can.
+		var err error
+		j.BookmarkData.FullText, err = j.BookmarkService.GetText(j.BookmarkData.Bookmark.ID)
+		if err != nil {
+			log.Printf("[%s] error fetching full text: %v", j.BookmarkData.GetID(), err)
+		}
+		j.BookmarkData.Highlights, err = j.HighlightService.List(j.BookmarkData.Bookmark.ID)
+		if err != nil {
+			log.Printf("[%s] error fetching highlights: %v", j.BookmarkData.GetID(), err)
+		}
+
 	}
-	if err := j.writeJSONFile(); err != nil {
-		log.Printf("[%s] error writing JSON: %v", j.BookmarkData.GetID(), err)
-	}
-	if err := j.writeJekyllPost(text); err != nil {
-		log.Printf("[%s] error writing jekyll post: %v", j.BookmarkData.GetID(), err)
-	}
-	if err := j.writeTextFile(text); err != nil {
-		log.Printf("[%s] error writing text: %v", j.BookmarkData.GetID(), err)
-	}
-	if err := j.writeHighlightsFile(); err != nil {
-		log.Printf("[%s] error writing highlights: %v", j.BookmarkData.GetID(), err)
+	if err := j.OutputWriter.Write(*j.BookmarkData); err != nil {
+		log.Printf("[%s] error writing: %v", j.BookmarkData.GetID(), err)
+		return err
 	}
 	log.Printf("[%s] archived bookmark", j.BookmarkData.GetID())
-}
-
-func (j *InstapaperBookmarkDownloadJob) writeJSONFile() error {
-	outputFilePath := filepath.Join(j.Directory, "_data", fmt.Sprintf("%s.json", j.BookmarkData.GetID()))
-	if fileExists(outputFilePath) {
-		return nil
-	}
-	data, err := json.MarshalIndent(j.BookmarkData, "", "  ")
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile(outputFilePath, data, 0644)
-}
-
-func (j *InstapaperBookmarkDownloadJob) writeJekyllPost(text string) error {
-	outputFilePath := filepath.Join(j.Directory, "_posts", fmt.Sprintf("%s-%s.html", j.BookmarkData.GetYYYYMMDD(), j.BookmarkData.GetID()))
-	if fileExists(outputFilePath) {
-		return nil
-	}
-	var buf bytes.Buffer
-	buf.WriteString("---\n")
-	buf.WriteString("archive_id: \"" + j.BookmarkData.GetID() + "\"\n")
-	buf.WriteString("title: \"" + strings.ReplaceAll(j.BookmarkData.GetTitle(), `"`, `\"`) + "\"\n")
-	buf.WriteString("---\n\n")
-	if len(text) > 0 {
-		buf.WriteString("{% raw %}\n")
-		buf.WriteString(text)
-		buf.WriteString("\n")
-		buf.WriteString("{% endraw %}\n")
-	}
-	return ioutil.WriteFile(outputFilePath, buf.Bytes(), 0644)
-}
-
-func (j *InstapaperBookmarkDownloadJob) writeTextFile(text string) error {
-	if len(text) == 0 {
-		return nil
-	}
-
-	outputFilePath := filepath.Join(j.Directory, "_mirror", fmt.Sprintf("%s.html", j.BookmarkData.GetID()))
-	if fileExists(outputFilePath) {
-		return nil
-	}
-	return ioutil.WriteFile(outputFilePath, []byte(text), 0644)
-}
-
-func (j *InstapaperBookmarkDownloadJob) writeHighlightsFile() error {
-	if j.BookmarkData.Bookmark == nil || j.BookmarkData.Bookmark.ID == 0 {
-		return fmt.Errorf("no real bookmark ID")
-	}
-
-	outputFilePath := filepath.Join(j.Directory, "_data", fmt.Sprintf("%s.highlights.json", j.BookmarkData.GetID()))
-	if fileExists(outputFilePath) {
-		return nil
-	}
-	highlights, err := j.HighlightService.List(j.BookmarkData.Bookmark.ID)
-	if err != nil {
-		return err
-	}
-	if len(highlights) == 0 {
-		return nil // no highlights, no file
-	}
-	data, err := json.MarshalIndent(highlights, "", "  ")
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile(outputFilePath, data, 0644)
+	return nil
 }
 
 func fileExists(filename string) bool {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/gomodule/oauth1/oauth"
+	"github.com/ochronus/instapaper-go-client/instapaper"
+)
+
+const testEmailAddress = "test@example.com"
+const testPassword = "testPassword123"
+const testClientID = "client-id"
+const testClientSecret = "client-secret"
+
+func newTestInstapaperClient(emailAddress, password string, handler http.Handler) (*instapaper.Client, *httptest.Server, error) {
+	server := httptest.NewServer(handler)
+	apiClient := &instapaper.Client{
+		OAuthClient: oauth.Client{
+			SignatureMethod: oauth.HMACSHA1,
+			Credentials: oauth.Credentials{
+				Token:  testClientID,
+				Secret: testClientSecret,
+			},
+			TokenRequestURI: server.URL + "/oauth/access_token",
+		},
+		Username: emailAddress,
+		Password: password,
+		BaseURL:  server.URL,
+	}
+	authErr := apiClient.Authenticate()
+	if authErr != nil {
+		return nil, server, fmt.Errorf("error authenticating: %v", authErr)
+	}
+	return apiClient, server, nil
+}
+
+func fileContentsMatch(t *testing.T, path, expected string) {
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatalf("unable to open file: %v", err)
+	}
+	contents, err := ioutil.ReadAll(f)
+	if err != nil {
+		t.Fatalf("unable to read file: %v", err)
+	}
+	if !strings.Contains(string(contents), expected) {
+		t.Fatalf("file %q does not contain %q:\n\n%s\n---", path, expected, string(contents))
+	}
+}

--- a/output_jekyll.go
+++ b/output_jekyll.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type jekyllOutputWriter struct {
+	Directory string
+}
+
+func (w jekyllOutputWriter) Preflight() error {
+	if err := os.MkdirAll(w.Directory, 0755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(w.Directory+"/_posts", 0755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(w.Directory+"/_data", 0755); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(w.Directory+"/_mirror", 0755); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (w jekyllOutputWriter) Write(bookmark bookmarkData) error {
+	if err := w.writeJSONFile(bookmark); err != nil {
+		log.Printf("[%s] error writing JSON: %v", bookmark.GetID(), err)
+		return err
+	}
+	if err := w.writeJekyllPost(bookmark); err != nil {
+		log.Printf("[%s] error writing jekyll post: %v", bookmark.GetID(), err)
+		return err
+	}
+	if err := w.writeTextFile(bookmark); err != nil {
+		log.Printf("[%s] error writing text: %v", bookmark.GetID(), err)
+		return err
+	}
+	if err := w.writeHighlightsFile(bookmark); err != nil {
+		log.Printf("[%s] error writing highlights: %v", bookmark.GetID(), err)
+		return err
+	}
+	return nil
+}
+
+func (w jekyllOutputWriter) writeJSONFile(bookmark bookmarkData) error {
+	outputFilePath := filepath.Join(w.Directory, "_data", fmt.Sprintf("%s.json", bookmark.GetID()))
+	if fileExists(outputFilePath) {
+		return nil
+	}
+	data, err := json.MarshalIndent(bookmark, "", "  ")
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(outputFilePath, data, 0644)
+}
+
+func (w jekyllOutputWriter) writeJekyllPost(bookmark bookmarkData) error {
+	outputFilePath := filepath.Join(w.Directory, "_posts", fmt.Sprintf("%s-%s.html", bookmark.GetYYYYMMDD(), bookmark.GetID()))
+	if fileExists(outputFilePath) {
+		return nil
+	}
+	var buf bytes.Buffer
+	buf.WriteString("---\n")
+	buf.WriteString("archive_id: \"" + bookmark.GetID() + "\"\n")
+	buf.WriteString("title: \"" + strings.ReplaceAll(bookmark.GetTitle(), `"`, `\"`) + "\"\n")
+	buf.WriteString("---\n\n")
+	if len(bookmark.FullText) > 0 {
+		buf.WriteString("{% raw %}\n")
+		buf.WriteString(bookmark.FullText)
+		buf.WriteString("\n")
+		buf.WriteString("{% endraw %}\n")
+	}
+	return ioutil.WriteFile(outputFilePath, buf.Bytes(), 0644)
+}
+
+func (w jekyllOutputWriter) writeTextFile(bookmark bookmarkData) error {
+	if len(bookmark.FullText) == 0 {
+		return nil
+	}
+
+	outputFilePath := filepath.Join(w.Directory, "_mirror", fmt.Sprintf("%s.html", bookmark.GetID()))
+	if fileExists(outputFilePath) {
+		return nil
+	}
+	return ioutil.WriteFile(outputFilePath, []byte(bookmark.FullText), 0644)
+}
+
+func (w jekyllOutputWriter) writeHighlightsFile(bookmark bookmarkData) error {
+	if len(bookmark.Highlights) <= 0 {
+		return nil // no highlights
+	}
+
+	outputFilePath := filepath.Join(w.Directory, "_data", fmt.Sprintf("%s.highlights.json", bookmark.GetID()))
+	if fileExists(outputFilePath) {
+		return nil
+	}
+	data, err := json.MarshalIndent(bookmark.Highlights, "", "  ")
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(outputFilePath, data, 0644)
+}

--- a/output_jekyll_test.go
+++ b/output_jekyll_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ochronus/instapaper-go-client/instapaper"
+)
+
+var jekyllOutputWriterTestDir = filepath.Join("tmp", "jekyllOutputWriter")
+
+func cleanupTestTmpDir(dir string) {
+	if !strings.HasPrefix(dir, filepath.Join("tmp")) {
+		log.Printf("dir not in tmp: %q", dir)
+		return
+	}
+	_ = os.RemoveAll(dir)
+}
+
+func TestJekyllOutputWriter_Preflight(t *testing.T) {
+	w := jekyllOutputWriter{Directory: jekyllOutputWriterTestDir}
+	if err := w.Preflight(); err != nil {
+		t.Fatalf("preflight failed: %v", err)
+	}
+}
+
+func TestJekyllOutputWriter_Write(t *testing.T) {
+	w := jekyllOutputWriter{Directory: jekyllOutputWriterTestDir}
+	if err := w.Preflight(); err != nil {
+		t.Fatalf("preflight failed: %v", err)
+	}
+	defer cleanupTestTmpDir(jekyllOutputWriterTestDir)
+	bookmark := bookmarkData{
+		Bookmark: &instapaper.Bookmark{
+			Hash:              "hash1234",
+			Description:       "A description",
+			ID:                1234,
+			Title:             "Title for the bookmark",
+			URL:               "https://example.com/bookmark1234",
+			ProgressTimestamp: 5678,
+			Time:              1288584076,
+			Progress:          0.5,
+			Starred:           "starred1234",
+		},
+		BookmarkExportMeta: &bookmarkExportMeta{
+			URL:       "https://example.com/bookmark1234",
+			Title:     "Title for the bookmark",
+			Selection: "selection1234",
+			Folder:    instapaper.FolderIDUnread,
+			Timestamp: "1288584076",
+			Hash:      "hash1234",
+		},
+		FullText: "full text\n\nof an article",
+		Highlights: []instapaper.Highlight{
+			{
+				ID:         92841,
+				BookmarkID: 1234,
+				Text:       "Text of the highlight",
+				Note:       "Note for highlight",
+				Time:       json.Number(strconv.FormatInt(time.Now().UnixMilli(), 10)),
+				Position:   10,
+			},
+		},
+	}
+	if err := w.Write(bookmark); err != nil {
+		t.Fatalf("write failed: %v", err)
+	}
+
+	// Now, verify.
+	fileContentsMatch(t, filepath.Join(w.Directory, "_data", "1234.json"), `"Title": "Title for the bookmark",`)
+	fileContentsMatch(t, filepath.Join(w.Directory, "_data", "1234.highlights.json"), `"Text": "Text of the highlight",`)
+	fileContentsMatch(t, filepath.Join(w.Directory, "_mirror", "1234.html"), "full text\n\nof an article")
+	fileContentsMatch(t, filepath.Join(w.Directory, "_posts", "2010-10-31-1234.html"), `archive_id: "1234"`)
+	fileContentsMatch(t, filepath.Join(w.Directory, "_posts", "2010-10-31-1234.html"), "{% raw %}\nfull text\n\nof an article")
+}

--- a/output_jekyll_test.go
+++ b/output_jekyll_test.go
@@ -15,6 +15,12 @@ import (
 
 var jekyllOutputWriterTestDir = filepath.Join("tmp", "jekyllOutputWriter")
 
+func init() {
+	if err := os.MkdirAll("tmp", 0755); err != nil {
+		log.Fatalf("error creating tmp: %v", err)
+	}
+}
+
 func cleanupTestTmpDir(dir string) {
 	if !strings.HasPrefix(dir, filepath.Join("tmp")) {
 		log.Printf("dir not in tmp: %q", dir)

--- a/output_jekyll_test.go
+++ b/output_jekyll_test.go
@@ -34,6 +34,7 @@ func TestJekyllOutputWriter_Preflight(t *testing.T) {
 	if err := w.Preflight(); err != nil {
 		t.Fatalf("preflight failed: %v", err)
 	}
+	defer cleanupTestTmpDir(jekyllOutputWriterTestDir)
 }
 
 func TestJekyllOutputWriter_Write(t *testing.T) {
@@ -50,7 +51,7 @@ func TestJekyllOutputWriter_Write(t *testing.T) {
 			Title:             "Title for the bookmark",
 			URL:               "https://example.com/bookmark1234",
 			ProgressTimestamp: 5678,
-			Time:              1288584076,
+			Time:              1288608076,
 			Progress:          0.5,
 			Starred:           "starred1234",
 		},
@@ -59,7 +60,7 @@ func TestJekyllOutputWriter_Write(t *testing.T) {
 			Title:     "Title for the bookmark",
 			Selection: "selection1234",
 			Folder:    instapaper.FolderIDUnread,
-			Timestamp: "1288584076",
+			Timestamp: "1288608076",
 			Hash:      "hash1234",
 		},
 		FullText: "full text\n\nof an article",
@@ -82,6 +83,6 @@ func TestJekyllOutputWriter_Write(t *testing.T) {
 	fileContentsMatch(t, filepath.Join(w.Directory, "_data", "1234.json"), `"Title": "Title for the bookmark",`)
 	fileContentsMatch(t, filepath.Join(w.Directory, "_data", "1234.highlights.json"), `"Text": "Text of the highlight",`)
 	fileContentsMatch(t, filepath.Join(w.Directory, "_mirror", "1234.html"), "full text\n\nof an article")
-	fileContentsMatch(t, filepath.Join(w.Directory, "_posts", "2010-10-31-1234.html"), `archive_id: "1234"`)
-	fileContentsMatch(t, filepath.Join(w.Directory, "_posts", "2010-10-31-1234.html"), "{% raw %}\nfull text\n\nof an article")
+	fileContentsMatch(t, filepath.Join(w.Directory, "_posts", "2010-11-01-1234.html"), `archive_id: "1234"`)
+	fileContentsMatch(t, filepath.Join(w.Directory, "_posts", "2010-11-01-1234.html"), "{% raw %}\nfull text\n\nof an article")
 }

--- a/workers.go
+++ b/workers.go
@@ -11,7 +11,7 @@ import (
 
 // Job - interface for job processing
 type Job interface {
-	Process()
+	Process() error
 }
 
 // Worker - the worker threads that actually process the jobs
@@ -35,7 +35,7 @@ type JobQueue struct {
 
 // NewJobQueue - creates a new job queue
 func NewJobQueue(maxWorkers int) *JobQueue {
-	workersStopped := sync.WaitGroup{}
+	workersStopped := sync.WaitGroup{} // TODO: convert to error
 	readyPool := make(chan chan Job, maxWorkers)
 	workers := make([]*Worker, maxWorkers, maxWorkers)
 	for i := 0; i < maxWorkers; i++ {
@@ -106,7 +106,7 @@ func (w *Worker) Start() {
 			w.readyPool <- w.assignedJobQueue // check the job queue in
 			select {
 			case job := <-w.assignedJobQueue: // see if anything has been assigned to the queue
-				job.Process()
+				_ = job.Process() // TODO: propagate error into errgroup
 			case <-w.quit:
 				w.done.Done()
 				return


### PR DESCRIPTION
Our first output writer will be for the existing Jekyll implementation.
An output writer can expect the full text, highlights if available, and
all the bookmark data we have. The job will call to the Instapaper API and the writer will write to disk or wherever.

It's not clean or pretty, but it was a fun distraction on the plane.