### PR TITLE
jekyll: write posts & mirrors into subdirectories

### DIFF
--- a/data.go
+++ b/data.go
@@ -72,18 +72,26 @@ func (d bookmarkData) GetURL() string {
 	return "NO_URL"
 }
 
-func (d bookmarkData) GetYYYYMMDD() string {
+func (d bookmarkData) getTime() time.Time {
 	if d.Bookmark != nil && d.Bookmark.Time > 0 {
-		return time.Unix(int64(d.Bookmark.Time), 0).Format("2006-01-02")
+		return time.Unix(int64(d.Bookmark.Time), 0)
 	}
 	if d.BookmarkExportMeta != nil && d.BookmarkExportMeta.Timestamp != "" {
 		unix, err := strconv.Atoi(d.BookmarkExportMeta.Timestamp)
 		if err != nil {
-			return "2001-10-10" // error, Instapaper didn't exist then
+			return time.Date(2001, 10, 10, 0, 0, 0, 0, time.Now().Location()) // error, Instapaper didn't exist then
 		}
-		return time.Unix(int64(unix), 0).Format("2006-01-02")
+		return time.Unix(int64(unix), 0)
 	}
-	return "2000-01-01" // error, Instapaper didn't exist then
+	return time.Date(2000, 1, 1, 0, 0, 0, 0, time.Now().Location()) // error, Instapaper didn't exist then
+}
+
+func (d bookmarkData) GetYYYY() string {
+	return d.getTime().Format("2006")
+}
+
+func (d bookmarkData) GetYYYYMMDD() string {
+	return d.getTime().Format("2006-01-02")
 }
 
 func (d bookmarkData) String() string {

--- a/output_jekyll.go
+++ b/output_jekyll.go
@@ -64,9 +64,13 @@ func (w jekyllOutputWriter) writeJSONFile(bookmark bookmarkData) error {
 }
 
 func (w jekyllOutputWriter) writeJekyllPost(bookmark bookmarkData) error {
-	outputFilePath := filepath.Join(w.Directory, "_posts", fmt.Sprintf("%s-%s.html", bookmark.GetYYYYMMDD(), bookmark.GetID()))
+	outputFilePath := filepath.Join(
+		w.Directory, "_posts", bookmark.GetYYYY(), fmt.Sprintf("%s-%s.html", bookmark.GetYYYYMMDD(), bookmark.GetID()))
 	if fileExists(outputFilePath) {
 		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(outputFilePath), 0755); err != nil {
+		return err
 	}
 	var buf bytes.Buffer
 	buf.WriteString("---\n")
@@ -80,7 +84,7 @@ func (w jekyllOutputWriter) writeJekyllPost(bookmark bookmarkData) error {
 		buf.WriteString("\n")
 		buf.WriteString("{% endraw %}\n")
 	}
-	return ioutil.WriteFile(outputFilePath, buf.Bytes(), 0644)
+	return os.WriteFile(outputFilePath, buf.Bytes(), 0644)
 }
 
 func (w jekyllOutputWriter) writeTextFile(bookmark bookmarkData) error {
@@ -88,11 +92,15 @@ func (w jekyllOutputWriter) writeTextFile(bookmark bookmarkData) error {
 		return nil
 	}
 
-	outputFilePath := filepath.Join(w.Directory, "_mirror", fmt.Sprintf("%s.html", bookmark.GetID()))
+	outputFilePath := filepath.Join(
+		w.Directory, "_mirror", bookmark.GetYYYY(), fmt.Sprintf("%s.html", bookmark.GetID()))
 	if fileExists(outputFilePath) {
 		return nil
 	}
-	return ioutil.WriteFile(outputFilePath, []byte(bookmark.FullText), 0644)
+	if err := os.MkdirAll(filepath.Dir(outputFilePath), 0755); err != nil {
+		return err
+	}
+	return os.WriteFile(outputFilePath, []byte(bookmark.FullText), 0644)
 }
 
 func (w jekyllOutputWriter) writeHighlightsFile(bookmark bookmarkData) error {
@@ -108,5 +116,5 @@ func (w jekyllOutputWriter) writeHighlightsFile(bookmark bookmarkData) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(outputFilePath, data, 0644)
+	return os.WriteFile(outputFilePath, data, 0644)
 }

--- a/output_jekyll_test.go
+++ b/output_jekyll_test.go
@@ -83,8 +83,8 @@ func TestJekyllOutputWriter_Write(t *testing.T) {
 	// Now, verify.
 	fileContentsMatch(t, filepath.Join(w.Directory, "_data", "1234.json"), `"Title": "Title for the bookmark",`)
 	fileContentsMatch(t, filepath.Join(w.Directory, "_data", "1234.highlights.json"), `"Text": "Text of the highlight",`)
-	fileContentsMatch(t, filepath.Join(w.Directory, "_mirror", "1234.html"), "full text\n\nof an article")
-	fileContentsMatch(t, filepath.Join(w.Directory, "_posts", "2010-11-01-1234.html"), `archive_id: "1234"`)
-	fileContentsMatch(t, filepath.Join(w.Directory, "_posts", "2010-11-01-1234.html"), `category: "Books To Read"`)
-	fileContentsMatch(t, filepath.Join(w.Directory, "_posts", "2010-11-01-1234.html"), "{% raw %}\nfull text\n\nof an article")
+	fileContentsMatch(t, filepath.Join(w.Directory, "_mirror", "2010", "1234.html"), "full text\n\nof an article")
+	fileContentsMatch(t, filepath.Join(w.Directory, "_posts", "2010", "2010-11-01-1234.html"), `archive_id: "1234"`)
+	fileContentsMatch(t, filepath.Join(w.Directory, "_posts", "2010", "2010-11-01-1234.html"), `category: "Books To Read"`)
+	fileContentsMatch(t, filepath.Join(w.Directory, "_posts", "2010", "2010-11-01-1234.html"), "{% raw %}\nfull text\n\nof an article")
 }


### PR DESCRIPTION
**BREAKING CHANGE**.

This writes all the posts & mirrors into subdirectories based on the YYYY of the bookmark:

- `_posts/2010-12-22-1234.html` -> `_posts/2010/2010-12-22-1234.html`
- `_mirror/1234.html` -> `_mirror/2010/1234.html`.

This makes things a bit more browsable.